### PR TITLE
Update leaderboard and difficulty

### DIFF
--- a/src/Components/Audio/Audio.js
+++ b/src/Components/Audio/Audio.js
@@ -1,39 +1,9 @@
-import React, {useState, useEffect} from "react";
-import './Audio.css'
+import React from "react";
+import "./Audio.css";
 import ReactAudioPlayer from "react-audio-player";
 
-const Audio = ({audioURL, difficulty, turn}) => {
+const Audio = ({ audioURL }) => {
+  return <ReactAudioPlayer src={audioURL} controls />;
+};
 
-  const[audioClicks, setAudioClicks] = useState(0)
-  const[disable,setDisable] = useState("show")
-
-  useEffect(()=>{
-    setDisable("show")
-    if(difficulty === "easy"){
-      setAudioClicks(3)
-    } else if (difficulty === "medium") {
-      setAudioClicks(2)
-    } else {
-      setAudioClicks(1)
-    }
-  },[turn])
-
-  const handleAudioClick = () => {
-    if (audioClicks > 1){
-      setAudioClicks(audioClicks-1)
-    } else {
-      setDisable("hide")
-    }
-  }
-
-  return (
-      <ReactAudioPlayer
-        src={audioURL}
-        controls
-        onPlay={()=> handleAudioClick()}
-        className={disable}
-      />
-  )
-}
-
-export default Audio
+export default Audio;

--- a/src/Components/Game/Game.js
+++ b/src/Components/Game/Game.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./Game.css";
 import Question from "../Question/Question";
 import Loading from "../Loading/Loading";
@@ -38,7 +38,7 @@ function Game() {
       {error ? (
         <ErrorDisplay errorCode="500" />
       ) : deckID ? (
-        <Question deckID={deckID} difficulty={location[2]} />
+        <Question deckID={deckID} />
       ) : (
         <Loading />
       )}

--- a/src/Components/Game/Game.js
+++ b/src/Components/Game/Game.js
@@ -1,43 +1,49 @@
 import React, { Fragment, useEffect, useState } from "react";
-import "./Game.css"
-import Question from '../Question/Question'
-import Loading from '../Loading/Loading'
-import { useLocation, useNavigate } from 'react-router-dom'
-import ErrorDisplay from "../ErrorDisplay/ErrorDisplay"
+import "./Game.css";
+import Question from "../Question/Question";
+import Loading from "../Loading/Loading";
+import { useLocation, useNavigate } from "react-router-dom";
+import ErrorDisplay from "../ErrorDisplay/ErrorDisplay";
 import { getData } from "../../GraphQL/ApiCall";
 import { createCategoryQuery } from "../../GraphQL/Mutations";
 
- function Game()  {
-  const [deckID,setDeckID] = useState(0)
-  const [error, setError] = useState('')
-  const categories = ['animals', 'instruments', 'machines', 'misc']
-  const difficulties = ['easy', 'medium', 'hard']
-  const navigate = useNavigate()
+function Game() {
+  const [deckID, setDeckID] = useState(0);
+  const [error, setError] = useState("");
+  const categories = ["animals", "instruments", "machines", "misc"];
+  const difficulties = ["easy", "medium", "hard"];
+  const navigate = useNavigate();
 
-  let location = useLocation().pathname.split("/")
+  let location = useLocation().pathname.split("/");
 
   useEffect(() => {
-    if(!categories.includes(location[1]) || !difficulties.includes(location[2])) {
-      navigate('/404')
+    if (
+      !categories.includes(location[1]) ||
+      !difficulties.includes(location[2])
+    ) {
+      navigate("/404");
     }
-  
-    const categoryQuery = createCategoryQuery(location[1])
-    
+
+    const categoryQuery = createCategoryQuery(location[1], location[2]);
+
     getData(categoryQuery)
-    .then(data => {
-      setDeckID(data.data.createDeck.deck.id)
-    })
-    .catch(err => setError(err))
-  }, [])
-  
+      .then((data) => {
+        setDeckID(data.data.createDeck.deck.id);
+      })
+      .catch((err) => setError(err));
+  }, []);
+
   return (
     <div className="question-container">
-      {error 
-      ? <ErrorDisplay errorCode='500' /> 
-      : 
-      deckID ? <Question deckID={deckID} difficulty={location[2]}/> : <Loading/>}
+      {error ? (
+        <ErrorDisplay errorCode="500" />
+      ) : deckID ? (
+        <Question deckID={deckID} difficulty={location[2]} />
+      ) : (
+        <Loading />
+      )}
     </div>
-  )
- }
+  );
+}
 
-export default Game
+export default Game;

--- a/src/Components/Leaderboard/Leaderboard.css
+++ b/src/Components/Leaderboard/Leaderboard.css
@@ -50,7 +50,15 @@ tbody tr:nth-child(odd) {
     color: rgb(8, 189, 189);
 }
 
-@media screen and (max-width: 700px) {
-  
+@media screen and (max-width: 600px) {
+  table {
+    width: 100%;
+    font-size: 1.3em;
+  }
 }
 
+@media screen and (max-width: 300px) {
+  table {
+    font-size: .9em;
+  }
+}

--- a/src/Components/Leaderboard/Leaderboard.css
+++ b/src/Components/Leaderboard/Leaderboard.css
@@ -23,7 +23,7 @@ table {
 }
 
 thead {
-    background-color: #29BF12;
+    background-color: rgb(8, 189, 189);
     color: #fff;
     position: sticky;
     top: 0;

--- a/src/Components/Leaderboard/Leaderboard.css
+++ b/src/Components/Leaderboard/Leaderboard.css
@@ -12,6 +12,7 @@
 table {
     border: 1px solid rgb(190, 190, 190);
     border-collapse: collapse;
+    box-shadow: 1px 10px 30px rgb(90 90 90);
     border-radius: 10px;
     display:block; 
     font-family: sans-serif;
@@ -19,7 +20,7 @@ table {
     height: 50vh; 
     letter-spacing: 1px;
     overflow-y:scroll; 
-    width: fit-content;
+    width: 90%;
 }
 
 thead {
@@ -31,7 +32,7 @@ thead {
 
 td,
 th {
-    border: 1px solid rgb(190, 190, 190);
+    border-bottom: 1px solid rgb(190, 190, 190);
     padding: 5px 10px;
 }
 
@@ -48,3 +49,8 @@ tbody tr:nth-child(odd) {
     background-color: #fff;
     color: rgb(8, 189, 189);
 }
+
+@media screen and (max-width: 700px) {
+  
+}
+

--- a/src/Components/Leaderboard/Leaderboard.css
+++ b/src/Components/Leaderboard/Leaderboard.css
@@ -41,10 +41,10 @@ td {
 
 tbody tr:nth-child(even) {
     background-color: #f5f5f5;
-    color: #29BF12
+    color: rgb(8, 189, 189);
 }
 
 tbody tr:nth-child(odd) {
     background-color: #fff;
-    color: #29BF12
+    color: rgb(8, 189, 189);
 }

--- a/src/Components/Leaderboard/Leaderboard.js
+++ b/src/Components/Leaderboard/Leaderboard.js
@@ -34,9 +34,9 @@ const Leaderboard = ({ handleClose }) => {
               <table className="container">
                 <thead>
                   <tr>
-                    <th style={{"width":"20%"}}>Rank</th>
-                    <th style={{"width":"50%"}}>Name</th>
-                    <th style={{"width":"20%"}}>Score</th>
+                    <th style={{"width":"30%"}}>Rank</th>
+                    <th style={{"width":"60%", "textAlign": "left"}}>Name</th>
+                    <th style={{"width":"10%"}}>Score</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/Components/Modal/Modal.js
+++ b/src/Components/Modal/Modal.js
@@ -1,31 +1,42 @@
-import React from 'react';
-import {IoCloseSharp} from 'react-icons/io5'
-import Leaderboard from '../Leaderboard/Leaderboard';
-import './Modal.css'
+import React from "react";
+import { IoCloseSharp } from "react-icons/io5";
+import Leaderboard from "../Leaderboard/Leaderboard";
+import "./Modal.css";
 
 const Modal = ({ show, handleClose, display }) => {
   const showHideClassName = show ? "modal display-block" : "modal display-none";
 
   return (
     <div className={showHideClassName}>
-        {display === 'leader' ?
-            <Leaderboard handleClose={handleClose} />
-                :
-            <section className="modal-main">
-                <IoCloseSharp className='close-Btn' onClick={handleClose} />
-                <h2>How To Play</h2>
-                <ol>
-                    <li>Choose a category of sounds that you want to play with.</li>
-                    <li>Choose a difficulty level that you are comfortable with.</li>
-                        <ul>
-                            <li>Easy: Listen to the sound 3 times</li>
-                            <li>Medium: Listen to the sound 2 times</li>
-                            <li>Hard: Listen to the sound 1 times</li>
-                        </ul>
-                    <li>After you have guessed all eight sounds, your score will be displayed.</li>
-                </ol>
-            </section>
-        }
+      {display === "leader" ? (
+        <Leaderboard handleClose={handleClose} />
+      ) : (
+        <section className="modal-main">
+          <IoCloseSharp className="close-Btn" onClick={handleClose} />
+          <h2>How To Play</h2>
+          <ol>
+            <li>Choose a category of sounds that you want to play with.</li>
+            <li>Choose a difficulty level that you are comfortable with.</li>
+            <ul>
+              <li>
+                Easy: Can you tell the difference between an elephant and a dog?
+              </li>
+              <li>
+                Medium: Can you tell the difference between a vacuum and a blow
+                dryer?
+              </li>
+              <li>
+                Hard: Can you tell the difference between a VHS and a casette
+                player?
+              </li>
+            </ul>
+            <li>
+              After you have guessed all eight sounds, your score will be
+              displayed.
+            </li>
+          </ol>
+        </section>
+      )}
     </div>
   );
 };

--- a/src/Components/Question/Question.js
+++ b/src/Components/Question/Question.js
@@ -1,74 +1,81 @@
 import React, { useState, useEffect } from "react";
 import "./Question.css";
-import Audio from '../Audio/Audio'
+import Audio from "../Audio/Audio";
 import Choices from "../Choices/Choices";
-import ErrorDisplay from "../ErrorDisplay/ErrorDisplay"
+import ErrorDisplay from "../ErrorDisplay/ErrorDisplay";
 import Endgame from "../Endgame/Endgame";
 import Loading from "../Loading/Loading";
 import { useLocation } from "react-router";
 import { getData } from "../../GraphQL/ApiCall";
 import { createCardQuery } from "../../GraphQL/Queries";
 
-const Question = ({ deckID, difficulty }) => {
+// const Question = ({ deckID, difficulty }) => {
+const Question = ({ deckID }) => {
+  const [turn, setTurn] = useState(1);
+  const [card, setCard] = useState({});
+  const [correctAnswers, setCorrectAnswers] = useState(0);
+  const [answers, setAnswers] = useState([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
 
-  const [turn,setTurn] = useState(1)
-  const [card,setCard] = useState({})
-  const [correctAnswers, setCorrectAnswers] = useState(0)
-  const [answers, setAnswers] = useState([])
-  const [error, setError] = useState('')
-  const [loading,setLoading] = useState(true)
-
-  let location = useLocation().pathname.split("/")
+  let location = useLocation().pathname.split("/");
 
   const advanceTurn = (e) => {
-    e.preventDefault()
-    setTimeout(() => setTurn(turn + 1), 2000)
-  }
+    e.preventDefault();
+    setTimeout(() => setTurn(turn + 1), 2000);
+  };
 
   const addCorrectAnswer = () => {
-    setCorrectAnswers(correctAnswers + 1)
-  }
+    setCorrectAnswers(correctAnswers + 1);
+  };
 
   useEffect(() => {
-    const cardQuery = createCardQuery(deckID)
+    const cardQuery = createCardQuery(deckID);
 
-    if(turn < 9) {
+    if (turn < 9) {
       getData(cardQuery)
-      .then(data => {
-        setCard(data.data.soundCard)
-        const newCard = data.data.soundCard
-        const answers = [...newCard.wrongAnswers, newCard.correctAnswer]
-        const shuffledAnswers = answers.sort(() => Math.random() - .5)
-        setAnswers(shuffledAnswers)
-        setLoading(false)
-      })
-      .catch(err => setError(err))
+        .then((data) => {
+          setCard(data.data.soundCard);
+          const newCard = data.data.soundCard;
+          const answers = [...newCard.wrongAnswers, newCard.correctAnswer];
+          const shuffledAnswers = answers.sort(() => Math.random() - 0.5);
+          setAnswers(shuffledAnswers);
+          setLoading(false);
+        })
+        .catch((err) => setError(err));
     }
-  }, [deckID, turn])
+  }, [deckID, turn]);
 
   return (
-  <div className="loading-container">
-    {error 
-    ? <ErrorDisplay errorCode='500' /> 
-    : (loading) ? <Loading /> : 
-    <div className="game-container">
-      {turn < 9 ? 
-      <div className='card' key={card.id}>
-        <h2 className='turn-count'>Question: {turn} / 8</h2>
-        <Audio audioURL={card.link} difficulty={difficulty} turn={turn}/>
-        <Choices
-          advanceTurn={advanceTurn} 
-          correctAnswer={card.correctAnswer}
-          shuffledAnswers={answers}
-          addCorrectAnswer={addCorrectAnswer}
-          />
-      </div> :
-      <Endgame correctAnswers={correctAnswers} category={location[1]} difficulty={location[2]}/>
-    }
+    <div className="loading-container">
+      {error ? (
+        <ErrorDisplay errorCode="500" />
+      ) : loading ? (
+        <Loading />
+      ) : (
+        <div className="game-container">
+          {turn < 9 ? (
+            <div className="card" key={card.id}>
+              <h2 className="turn-count">Question: {turn} / 8</h2>
+              <Audio audioURL={card.link} />
+              <Choices
+                advanceTurn={advanceTurn}
+                correctAnswer={card.correctAnswer}
+                shuffledAnswers={answers}
+                addCorrectAnswer={addCorrectAnswer}
+              />
+            </div>
+          ) : (
+            <Endgame
+              correctAnswers={correctAnswers}
+              category={location[1]}
+              difficulty={location[2]}
+            />
+          )}
+        </div>
+      )}
     </div>
-    }
-  </div>
-  )
-}
+  );
+};
 
-export default Question
+export default Question;

--- a/src/GraphQL/Mutations.js
+++ b/src/GraphQL/Mutations.js
@@ -1,9 +1,9 @@
-export const createCategoryQuery = (location) => {
-    return (
-      `
+export const createCategoryQuery = (location, difficulty) => {
+  return `
         mutation createDeck {
             createDeck(input: {
-                category: "${location}"
+                category: "${location}",
+                difficulty: "${difficulty}"
             }) 
             {
                 deck {
@@ -11,13 +11,11 @@ export const createCategoryQuery = (location) => {
                 }
             }
         }
-      `
-    )
-}
+      `;
+};
 
 export const createEndgameQuery = (name, score, category, difficulty) => {
-    return (
-      `
+  return `
         mutation createLeaderBoard {
             createLeaderboard(input: {
                 name: "${name}"
@@ -35,6 +33,5 @@ export const createEndgameQuery = (name, score, category, difficulty) => {
                 errors
             }
         }
-      `
-    )
-}
+      `;
+};


### PR DESCRIPTION
1. What's this PR do?
   - This changes the color of the leaderboard from green to teal.
   - Styling updates to the leaderboard.
   - Responsiveness in mobile views to leaderboard table.
   - Adds a parameter to query to send the user's difficulty selection to BE.
   - Changes the difficulty to be related to the cards supplied from BE instead of the number of play counts.
   - Update instructions to reflect change in difficulty
2. Where should the reviewer start?
   - Leaderboard.css
   - Audio.js
   - Game.js
   - Query files
3. How should this be manually tested?
     - If you don't have this repo locally, follow setup instructions in Readme then:
     - Run `git checkout Refactor/leaderboard-styling` 
     - Run server `npm start`
   - View changes listed above at http://localhost:3000/
5. Any background context you want to provide?
   - We wanted the difficulty to be related to the sounds themselves instead of the number of plays.  As the decks grow larger, this will make the game more fun for the user.
6. What are the relevant tickets?
#64 
#63 
7. Screenshots 
<img width="1406" alt="updated_leaderboard" src="https://github.com/Listen-Up-2210/listen-up-ui/assets/67208858/91ef8cf2-475c-4253-a1e9-6654cc0cc63d">

<img width="1042" alt="updated_instructions" src="https://github.com/Listen-Up-2210/listen-up-ui/assets/67208858/25814a45-99b4-4ea2-87b0-096d6b02ef85">


8. Questions:
    - Any additional styling requests for the leaderboard?
 

